### PR TITLE
Make `t` opaque

### DIFF
--- a/lib/nimble_parsec.ex
+++ b/lib/nimble_parsec.ex
@@ -161,7 +161,7 @@ defmodule NimbleParsec do
     end
   end
 
-  @type t :: [combinator]
+  @opaque t :: [combinator]
   @type bin_modifiers :: :integer | :utf8 | :utf16 | :utf32
   @type range :: inclusive_range | exclusive_range
   @type inclusive_range :: Range.t() | char()


### PR DESCRIPTION
`t` is defined using `combinator` which doesn't have a doc entry because it's private, so I figured it makes sense to make one of them opaque.