### PR TITLE
Add eof combinator

### DIFF
--- a/lib/nimble_parsec.ex
+++ b/lib/nimble_parsec.ex
@@ -182,6 +182,7 @@ defmodule NimbleParsec do
   @typep bound_combinator ::
            {:bin_segment, [inclusive_range], [exclusive_range], [bin_modifiers]}
            | {:string, binary}
+           | :eof
 
   @typep maybe_bound_combinator ::
            {:label, t, binary}
@@ -595,6 +596,32 @@ defmodule NimbleParsec do
       :__runtime_string__,
       [quote(do: utf8)]
     )
+  end
+
+  @doc ~S"""
+  Defines an end of file combinator.
+
+  The end of file does not produce a token and can be parsed multiple times.
+  This function is useful to avoid having to check for an empty remainder after
+  a successful parse.
+
+  ## Examples
+
+      defmodule MyParser do
+        import NimbleParsec
+
+        defparsec :letter_pairs, utf8_string([], 2) |> repeat() |> eof()
+      end
+
+      MyParser.letter_pairs("hi")
+      #=> {:ok, ["hi"], "", %{}, {1, 0}, 2}
+
+      MyParser.letter_pairs("hello")
+      #=> {:error, "expected end of file", "o", %{}, {1, 0}, 4}
+  """
+  @spec eof(t) :: t
+  def eof(combinator \\ empty()) do
+    [:eof | combinator]
   end
 
   @doc ~S"""

--- a/lib/nimble_parsec/compiler.ex
+++ b/lib/nimble_parsec/compiler.ex
@@ -683,6 +683,11 @@ defmodule NimbleParsec.Compiler do
     end
   end
 
+  defp bound_combinator(:eof, line, offset, counter) do
+    guard = quote(do: byte_size(rest) == 0)
+    {:ok, [], [guard], [], line, offset, counter}
+  end
+
   defp bound_combinator(_, _line, _offset, _counter) do
     :error
   end
@@ -756,6 +761,10 @@ defmodule NimbleParsec.Compiler do
       end
 
     prefix <> Enum.join([Enum.join(inclusive, " or") | exclusive], ", and not")
+  end
+
+  defp label(:eof) do
+    "end of file"
   end
 
   defp label({:repeat, combinators, _}) do

--- a/test/nimble_parsec_test.exs
+++ b/test/nimble_parsec_test.exs
@@ -1184,6 +1184,19 @@ defmodule NimbleParsecTest do
     end
   end
 
+  describe "eof/1 combinator" do
+    defparsecp :only_eof, eof()
+    defparsecp :multi_eof, eof() |> eof()
+
+    @error "expected end of file"
+
+    test "returns ok/error" do
+      assert only_eof("") == {:ok, [], "", %{}, {1, 0}, 0}
+      assert only_eof("a") == {:error, @error, "a", %{}, {1, 0}, 0}
+      assert multi_eof("") == {:ok, [], "", %{}, {1, 0}, 0}
+    end
+  end
+
   defp location(_rest, args, %{} = context, line, offset, tag) do
     {[{tag, args, line, offset}], context}
   end


### PR DESCRIPTION
Errors with multiple eof combinators might be awkward as its `end of file, followed by end of file`.