### PR TITLE
fix module name in Use cases doc

### DIFF
--- a/lib/nimble_parsec.ex
+++ b/lib/nimble_parsec.ex
@@ -297,7 +297,7 @@ defmodule NimbleParsec do
         end
       end
 
-      defmodule MyParser.Helpers do
+      defmodule MyParser do
         import NimbleParsec
         import MyParser.Helpers
 


### PR DESCRIPTION
`MyParser.Helpers` was defined in duplicate. 

I deleted `.Helpers` from the second.