### PR TITLE
Fix @spec for tag/3

### DIFF
--- a/lib/nimble_parsec.ex
+++ b/lib/nimble_parsec.ex
@@ -463,7 +463,7 @@ defmodule NimbleParsec do
       #=> {:error, "expected a digit followed by lowercase letter", "a1", %{}, {1, 0}, 0}
 
   """
-	@spec label(t, t, String.t) :: t
+  @spec label(t, t, String.t()) :: t
   def label(combinator \\ empty(), to_label, label)
       when is_combinator(combinator) and is_combinator(to_label) and is_binary(label) do
     non_empty!(to_label, "label")
@@ -1644,7 +1644,7 @@ defmodule NimbleParsec do
   def __compile_string__(_rest, acc, context, _line, _offset, _count, type) when is_list(acc) do
     acc =
       for entry <- :lists.reverse(acc) do
-        {:::, [], [entry, type]}
+        {:"::", [], [entry, type]}
       end
 
     {[{:<<>>, [], acc}], context}

--- a/lib/nimble_parsec.ex
+++ b/lib/nimble_parsec.ex
@@ -1020,7 +1020,7 @@ defmodule NimbleParsec do
   the parser is expected to emit multiple tokens. When you are sure that
   only a single token is emitted, you should use `unwrap_and_tag/3`.
   """
-  @spec tag(t, t) :: t
+  @spec tag(t, t, term) :: t
   def tag(combinator \\ empty(), to_tag, tag)
       when is_combinator(combinator) and is_combinator(to_tag) do
     quoted_post_traverse(combinator, to_tag, {__MODULE__, :__tag__, [Macro.escape(tag)]})

--- a/lib/nimble_parsec.ex
+++ b/lib/nimble_parsec.ex
@@ -463,6 +463,7 @@ defmodule NimbleParsec do
       #=> {:error, "expected a digit followed by lowercase letter", "a1", %{}, {1, 0}, 0}
 
   """
+	@spec label(t, t, String.t) :: t
   def label(combinator \\ empty(), to_label, label)
       when is_combinator(combinator) and is_combinator(to_label) and is_binary(label) do
     non_empty!(to_label, "label")

--- a/lib/nimble_parsec/compiler.ex
+++ b/lib/nimble_parsec/compiler.ex
@@ -938,7 +938,7 @@ defmodule NimbleParsec.Compiler do
 
       _ ->
         modifiers = Enum.map(modifiers, &Macro.var(&1, __MODULE__))
-        {:::, [], [expr, Enum.reduce(modifiers, &{:-, [], [&2, &1]})]}
+        {:"::", [], [expr, Enum.reduce(modifiers, &{:-, [], [&2, &1]})]}
     end
   end
 


### PR DESCRIPTION
Similar to `unwrap_and_tag/3`, the `@spec` for `tag/3` was missing the third parameter leading to dialyzer errors.
